### PR TITLE
Update TP 5

### DIFF
--- a/4_c/tp/5_string.ipynb
+++ b/4_c/tp/5_string.ipynb
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "d2f27738-5289-43e8-a9cd-ac9837a89d31",
    "metadata": {
     "execution": {
@@ -65,7 +65,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "00a765ab-5425-426e-921d-71d31c258da5",
    "metadata": {
     "execution": {
@@ -127,7 +127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "4c1b1caa-2196-4783-acbf-4052b3a4c597",
    "metadata": {
     "execution": {
@@ -193,7 +193,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "ed0f8c74-8a76-477f-aa5f-85470c899761",
    "metadata": {
     "execution": {
@@ -250,7 +250,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "69f4c101-1f39-47d2-9f5b-357ed0f457bd",
    "metadata": {
     "execution": {
@@ -267,7 +267,7 @@
     {
      "data": {
       "text/plain": [
-       "3844"
+       "9652"
       ]
      },
      "execution_count": 5,
@@ -280,10 +280,10 @@
     "    int somme = 0;\n",
     "    int puiss = 1; // variable pour stocker les puissances de p\n",
     "    for(int i = 0; s[i] != '\\0'; i++) {\n",
-    "        somme = (somme + hash(s[i])*p) % n;\n",
-    "        puiss = (puiss*p) % n;\n",
+    "        somme += hash(s[i])*puiss;\n",
+    "        puiss = (puiss*p;\n",
     "    }\n",
-    "    return somme;\n",
+    "    return somme % n;\n",
     "}\n",
     "\n",
     "h(\"helloworld\", 31, 11867)  // exemple de codage"
@@ -312,7 +312,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "1f3fcd62-dee8-476b-b1b3-9d41fbdaec69",
    "metadata": {
     "execution": {
@@ -346,7 +346,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "cc500101-0782-48cc-aef7-2e40e3396459",
    "metadata": {
     "execution": {
@@ -380,7 +380,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "c36cb14d-75ef-4828-98e9-227bd7357fd6",
    "metadata": {
     "execution": {
@@ -431,7 +431,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "1a5d267b-56c2-48d9-9012-8d97a30d0806",
    "metadata": {
     "execution": {
@@ -451,7 +451,7 @@
        "\"bc\""
       ]
      },
-     "execution_count": 9,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }


### PR DESCRIPTION
Modification de la fonction 'h' qui était différente de la formule de l'énoncé et donc renvoyait la même valeur si des mots étaient des anagrammes. ("dlrowolleh" et "helloworld").
Cela entrainait aussi une erreur dans la fonction 'most_frequent_word' qui comptait deux fois le mot "ba" dans "bab" et donc renvoyé "ba" pour le mot "babczbczbcaba" alors que "ba" apparaît 2 fois et "bc"  3 fois.