### PR TITLE
Fix mauvais lien

### DIFF
--- a/files/README.md
+++ b/files/README.md
@@ -1,6 +1,6 @@
 Programmer : [Binder](https://mybinder.org/v2/gh/fortierq/mp2i-binder/main?urlpath=git-pull%3Frepo%3Dhttps%253A%252F%252Fgithub.com%252Ffortierq%252Fmp2i-info.github.io%26urlpath%3Dlab%252Ftree%252Fmp2i-info.github.io%252F%26branch%3Dmain) | [Basthon](https://notebook.basthon.fr/ocaml) | [repl.it](https://replit.com/languages/c)
 
-Exos : [https://ocaml.org/problems](https://ocaml.org/problems)
+Exos : [https://ocaml.org/exercises](https://ocaml.org/exercises)
  
 Librairie des algorithmes de MP2I : [en OCaml](https://github.com/fortierq/mp2i-library-ocaml) | [en C](https://github.com/fortierq/mp2i-library-c)  
 
@@ -17,3 +17,4 @@ Concours MPI : [ENS](https://diplome.di.ens.fr/informatique-ens) | [Mines Pont](
     <div id="graph" style="height: 450px; width: 100%; margin: 0px auto;"></div>
     <script src="site/graph_mp2i/graph.js"></script>
 </body>
+


### PR DESCRIPTION
Le lien "problems ocaml" redirigeait vers une page qui n'existait plus sur le site d'Ocaml.
Je l'ai modifié pour [https://ocaml.org/exercises](https://ocaml.org/exercises)